### PR TITLE
Removing monitored_navigation as required component.

### DIFF
--- a/strands_recovery_behaviours/CMakeLists.txt
+++ b/strands_recovery_behaviours/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(strands_recovery_behaviours)
-find_package(catkin REQUIRED monitored_navigation)
+find_package(catkin REQUIRED)
 catkin_package()
 
 install(DIRECTORY launch


### PR DESCRIPTION
Not needed for a pseudo metapackage and breaks the build.
