### PR TITLE
only logs to db if explicitly told to do it

### DIFF
--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/mongo_logger.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/mongo_logger.py
@@ -33,8 +33,10 @@ class MonitoredNavEventClass:
         self.nav_event.n_help_requests=n_tries
     
     def insert(self):
-        message_proxy=MessageStoreProxy(collection='monitored_nav_events')
-        message_proxy.insert(self.nav_event)
+        log_to_db=rospy.get_param('log_mon_nav_events',False)
+        if log_to_db:
+            message_proxy=MessageStoreProxy(collection='monitored_nav_events')
+            message_proxy.insert(self.nav_event)
         self.pub.publish(self.nav_event)
 
 


### PR DESCRIPTION
to avoid the addition of redundant data to the db
