### PR TITLE
[backtrack_behaviour] Don't backtrack if no head camera, smaller pan

### DIFF
--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -54,7 +54,7 @@ class BacktrackServer(object):
         
         self.server = actionlib.SimpleActionServer('do_backtrack', BacktrackAction, self.execute, False)
         self.server.start()
-        rospy.loginfo("/do_backtrack action server started") 
+        rospy.loginfo("/do_backtrack action server started")
         
     def global_planner_checker_cb(self, msg):
         self.global_plan = msg
@@ -107,7 +107,11 @@ class BacktrackServer(object):
         config = self.move_base_reconfig_client.update_configuration(params)
                                                   
     def execute(self, goal):
-        #back track in elegant fashion     
+        #back track in elegant fashion
+        sources = rospy.param_get("/move_base/local_costmap/obstacle_layer/observation_sources")
+        if "head_cloud_sensor" not in sources:
+            self.server.set_aborted()
+            return # 'failure'
         try:
             previous_position = rospy.ServiceProxy('previous_position', PreviousPosition)
             meter_back = previous_position(goal.meters_back)
@@ -125,10 +129,10 @@ class BacktrackServer(object):
         self.feedback.status = "Moving the PTU"
         self.server.publish_feedback(self.feedback)
         ptu_goal = PtuGotoGoal();
-        ptu_goal.pan = 179
+        ptu_goal.pan = -175
         ptu_goal.tilt = 30
-        ptu_goal.pan_vel = 20
-        ptu_goal.tilt_vel = 20
+        ptu_goal.pan_vel = 30
+        ptu_goal.tilt_vel = 30
         self.ptu_action_client.send_goal(ptu_goal)
         self.ptu_action_client.wait_for_result()
         

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -110,6 +110,7 @@ class BacktrackServer(object):
         #back track in elegant fashion
         sources = rospy.param_get("/move_base/local_costmap/obstacle_layer/observation_sources")
         if "head_cloud_sensor" not in sources:
+            rospy.logwarn("Navigation with head camera not active in move_base configuration, aborting...")
             self.server.set_aborted()
             return # 'failure'
         try:

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -108,7 +108,7 @@ class BacktrackServer(object):
                                                   
     def execute(self, goal):
         #back track in elegant fashion
-        sources = rospy.param_get("/move_base/local_costmap/obstacle_layer/observation_sources")
+        sources = rospy.get_param("/move_base/local_costmap/obstacle_layer/observation_sources")
         if "head_cloud_sensor" not in sources:
             rospy.logwarn("Navigation with head camera not active in move_base configuration, aborting...")
             self.server.set_aborted()


### PR DESCRIPTION
This pull:
- Sets the pan to -175 instead of 179 to avoid hitting the limit and cable stretching
- Returns failure if the head camera is not activated in the move_base configuration
- Increases the PTU speed from 20 to 30 by popular demand

Can someone like @lucasb-eyer test if this new limit avoids hitting the hardware limit of the PTU?
