### PR TITLE
 [backtrack_behaviour] Move speaking into the action server

### DIFF
--- a/backtrack_behaviour/CMakeLists.txt
+++ b/backtrack_behaviour/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   std_srvs
-  dynamic_reconfigure 
+  dynamic_reconfigure
   scitos_msgs
   scitos_ptu
   sensor_msgs
@@ -21,6 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   dynamic_reconfigure
   cmake_modules
+  mary_tts
 )
 
 ## System dependencies are found with CMake's conventions

--- a/backtrack_behaviour/package.xml
+++ b/backtrack_behaviour/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.12</version>
   <description>The backtrack_behaviour package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="nilsbore@gmail.com">Nils Bore</maintainer>
@@ -57,7 +57,8 @@
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>cmake_modules</build_depend>
-  
+  <build_depend>mary_tts</build_depend>
+
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
@@ -74,6 +75,7 @@
   <run_depend>pcl_ros</run_depend>
   <run_depend>libpcl-all</run_depend>
   <run_depend>eigen</run_depend>
+  <run_depend>mary_tts</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -195,7 +195,7 @@ class BacktrackServer(object):
                 resp = self.planner(plan_request)
                 if len(resp.plan.poses) > 0:
                     self.speaker.send_goal(maryttsGoal(text=self.speech))
-                    rospy.sleep(2)
+                    rospy.sleep(5)
             except rospy.ServiceException as exc:
                 print("Service did not process request: " + str(exc))
 

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -2,15 +2,6 @@
 
 import rospy
 
-#import smach
-#import smach_ros
-
-#from scitos_msgs.srv import ResetMotorStop
-#from scitos_msgs.srv import EnableMotors
-#from std_srvs.srv import Empty
-#from scitos_msgs.msg import MotorStatus
-#from geometry_msgs.msg import Twist
-
 from nav_msgs.msg import Path
 from move_base_msgs.msg import *
 import dynamic_reconfigure.client
@@ -19,48 +10,58 @@ from backtrack_behaviour.srv import PreviousPosition
 from backtrack_behaviour.srv import RepublishPointcloud
 from actionlib_msgs.msg import *
 from geometry_msgs.msg import Pose
+from mary_tts.msg import maryttsAction, maryttsGoal
 
 import actionlib
 
 from backtrack_behaviour.msg import BacktrackAction, BacktrackResult, BacktrackFeedback
-
-#from logger import Loggable
-
-# this file has the recovery states that will be used when some failures are
-# detected. There is a recovery behaviour for move_base and another for when the
-# bumper is pressed
 
 class BacktrackServer(object):
     def __init__(self):
         rospy.init_node('backtrack_actionserver')
         self.consider_moving_success = True
 
+        # get ptu action client
         self.ptu_action_client = actionlib.SimpleActionClient('/SetPTUState', PtuGotoAction)
-        rospy.loginfo("Waiting for ptu action...") 
+        rospy.loginfo("Waiting for ptu action...")
         self.ptu_action_client.wait_for_server()
-        rospy.loginfo("Done") 
-        
+        rospy.loginfo("Done")
+
+        # get move_base action client
         self.move_base_action_client = actionlib.SimpleActionClient('/move_base', MoveBaseAction)
-        rospy.loginfo("Waiting for  move_base action...") 
+        rospy.loginfo("Waiting for move_base action...")
         self.move_base_action_client.wait_for_server()
-        rospy.loginfo("Done") 
+        rospy.loginfo("Done")
         self.move_base_reconfig_client = dynamic_reconfigure.client.Client('/move_base/DWAPlannerROS')
-        
+
+        # get mary_tts action client
+        self.speaker = actionlib.SimpleActionClient('/speak', maryttsAction)
+        got_server = self.speaker.wait_for_server(rospy.Duration(1))
+        while not got_server:
+            rospy.loginfo("Backtrack behaviour is waiting for marytts action...")
+            got_server = self.speaker.wait_for_server(rospy.Duration(1))
+            if rospy.is_shutdown():
+                return
+
+        rospy.loginfo("Backtrack behaviour got marytts action")
+        self.speech = "I am stuck here, so I might try moving backwards. Please get out of the way."
+
+        # set correct parameters and announce server
         self.global_plan = None
         self.last_global_plan_time = None
         rospy.Subscriber("/move_base/NavfnROS/plan" , Path, self.global_planner_checker_cb)
-        
+
         self.feedback = BacktrackFeedback()
         self.result = BacktrackResult()
-        
+
         self.server = actionlib.SimpleActionServer('do_backtrack', BacktrackAction, self.execute, False)
         self.server.start()
         rospy.loginfo("/do_backtrack action server started")
-        
+
     def global_planner_checker_cb(self, msg):
         self.global_plan = msg
         self.last_global_plan_time = rospy.get_rostime()
-    
+
     def stop_republish(self):
         try:
             republish_pointcloud = rospy.ServiceProxy('republish_pointcloud', RepublishPointcloud)
@@ -69,7 +70,7 @@ class BacktrackServer(object):
             rospy.logwarn("Couldn't stop republish pointcloud service, returning failure.")
             return False
         return True
-    
+
     def start_republish(self):
         try:
             republish_pointcloud = rospy.ServiceProxy('republish_pointcloud', RepublishPointcloud)
@@ -93,7 +94,7 @@ class BacktrackServer(object):
         if xdiff*xdiff + ydiff*ydiff > (meters_back+0.2)*(meters_back+0.2):
             return True
         return False
-        
+
     def has_moved(self):
         xdiff = self.x - self.first_x
         ydiff = self.y - self.first_y
@@ -112,7 +113,7 @@ class BacktrackServer(object):
     def reset_move_base_pars(self):
         params = { 'max_vel_x' : self.max_vel_x, 'min_vel_x' : self.min_vel_x }
         config = self.move_base_reconfig_client.update_configuration(params)
-                                                  
+
     def execute(self, goal):
         #back track in elegant fashion
         sources = rospy.get_param("/move_base/local_costmap/obstacle_layer/observation_sources")
@@ -127,13 +128,13 @@ class BacktrackServer(object):
             rospy.logwarn("Couldn't get previous position service, returning failure.")
             self.server.set_aborted()
             return # 'failure'
-            
+
         print "Got the previous position: ", meter_back.previous_pose.pose.position.x, ", ", meter_back.previous_pose.pose.position.y, ", ",  meter_back.previous_pose.pose.position.z
 
         self.move_base_action_client.cancel_all_goals() # begin by cancelling others
         self.first_pose = True
         pose_sub = rospy.Subscriber("/robot_pose" , Pose, self.pose_cb)
-        
+
         self.feedback.status = "Moving the PTU"
         self.server.publish_feedback(self.feedback)
         ptu_goal = PtuGotoGoal();
@@ -143,21 +144,21 @@ class BacktrackServer(object):
         ptu_goal.tilt_vel = 30
         self.ptu_action_client.send_goal(ptu_goal)
         self.ptu_action_client.wait_for_result()
-        
+
         if self.server.is_preempt_requested():
             self.reset_ptu()
             pose_sub.unregister()
             self.service_preempt()
             return
-            
+
         if self.start_republish() == False:
             self.reset_ptu()
             pose_sub.unregister()
             self.server.set_aborted()
             return # 'failure'
-            
+
         print "Managed to republish pointcloud."
-        
+
         self.max_vel_x = rospy.get_param("/move_base/DWAPlannerROS/max_vel_x")
         self.min_vel_x = rospy.get_param("/move_base/DWAPlannerROS/min_vel_x")
         params = { 'max_vel_x' : 0.2, 'min_vel_x' : -0.2 }
@@ -169,7 +170,7 @@ class BacktrackServer(object):
             pose_sub.unregister()
             self.service_preempt()
             return
-            
+
         self.feedback.status = "Moving the robot"
         self.server.publish_feedback(self.feedback)
         move_goal = MoveBaseGoal()
@@ -179,7 +180,8 @@ class BacktrackServer(object):
         #print movegoal
         self.move_base_action_client.send_goal(move_goal)
         status = self.move_base_action_client.get_state()
-        while status == GoalStatus.PENDING or status == GoalStatus.ACTIVE:   
+        did_speak = False
+        while status == GoalStatus.PENDING or status == GoalStatus.ACTIVE:
             status = self.move_base_action_client.get_state()
             if self.server.is_preempt_requested():
                 self.stop_republish()
@@ -196,11 +198,19 @@ class BacktrackServer(object):
                 pose_sub.unregister()
                 self.server.set_aborted()
                 return
+            if not did_speak:
+                 last_plan_recent = rospy.get_rostime() - self.last_global_plan_time < rospy.Duration.from_sec(1)
+                 last_plan_good = len(self.global_plan.poses) > 0
+                 if last_plan_recent and last_plan_good:
+                     self.speaker.send_goal(maryttsGoal(text=self.speech))
+                     did_speak = True
+                     #rospy.sleep(2)
+
             self.move_base_action_client.wait_for_result(rospy.Duration(0.2))
-        
+
         self.reset_move_base_pars()
         pose_sub.unregister()
-        
+
         if self.server.is_preempt_requested():
             self.stop_republish()
             self.service_preempt()
@@ -209,15 +219,15 @@ class BacktrackServer(object):
         if self.stop_republish() == False:
             self.server.set_aborted()
             return # 'failure'
-        
+
         self.reset_ptu()
 
         print "Reset PTU, move_base parameters and stopped republishing pointcloud."
-        
+
         if self.server.is_preempt_requested():
             self.service_preempt()
             return
-        
+
         if self.consider_moving_success and self.has_moved():
             self.result.status = 'failure_but_moved'
             self.server.set_succeeded(self.result)

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -191,8 +191,7 @@ class BacktrackServer(object):
                 plan_request = GetPlanRequest()
                 plan_request.start.pose = self.pose
                 plan_request.start.header.frame_id = '/map'
-                plan_request.goal.pose = move_goal.target_pose
-                plan_request.goal.header.frame_id = '/map'
+                plan_request.goal = move_goal.target_pose
                 resp = self.planner(plan_request)
                 if len(resp.plan.poses) > 0:
                     self.speaker.send_goal(maryttsGoal(text=self.speech))


### PR DESCRIPTION
Moved speaking from monitored nav states to backtrack, with check if it got a global plan. Only problem is that it might come a bit late right now, the robot starts moving at the same time as speaking. This might be a safety issue. @bfalacerda Do you know of any way to pause movement in move_base to let her finish speaking before moving?

Hold off on merging until we've discussed this.
