### PR TITLE
[walking_group_recovery] Not crashing if no files in data set

### DIFF
--- a/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
+++ b/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
@@ -135,8 +135,9 @@ class WalkingGroupRecovery(RecoverState):
         #paths = roslib.packages.find_resource('walking_group_recovery', 'good_bad_ugly.mp3')
         #pygame.mixer.music.load(paths[0])
         #pygame.mixer.music.play()
-        self.player = PyGamePlayer(0.2, 1.0, 0.5, frequency=44100)
-        self.player.play_music(self.get_random_song(), blocking=False)
+        if self.file_list is not None and len(self.file_list) > 0:
+            self.player = PyGamePlayer(0.2, 1.0, 0.5, frequency=44100)
+            self.player.play_music(self.get_random_song(), blocking=False)
         if self.being_helped:
             self.service_msg.interaction_status=AskHelpRequest.BEING_HELPED
             self.service_msg.interaction_service=self.help_finished_service_name
@@ -157,7 +158,7 @@ class WalkingGroupRecovery(RecoverState):
 
         self.was_helped=self.being_helped or self.help_finished
         self.finish_execution()
-        if self.was_helped:                       
+        if self.was_helped:
             return 'recovered_with_help'
         else:
             return 'recovered_without_help'


### PR DESCRIPTION
Just added a check to make sure it does not crash if you have not added any sounds to set `walking_group_recovery`. Still prints a warning at start up if that's the case.
