### PR TITLE
[walking_group_recovery] Walking external player

### DIFF
--- a/walking_group_recovery/launch/walking_group_recovery.launch
+++ b/walking_group_recovery/launch/walking_group_recovery.launch
@@ -12,15 +12,15 @@
 <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER)" user="$(arg user)" default="true"/>
 
 <node pkg="sound_player_server" type="sound_player.py" name="walking_group_player" output="screen" respawn="true">
-    <arg name="music_set" value="$(arg music_set)"/>
-    <arg name="audio_priority" value="$(arg audio_priority)"/>
-    <arg name="min_volume" value="$(arg min_volume)"/>
-    <arg name="max_volume" value="$(arg max_volume)"/>
+    <param name="music_set" value="$(arg music_set)"/>
+    <param name="audio_priority" value="$(arg audio_priority)"/>
+    <param name="min_volume" value="$(arg min_volume)"/>
+    <param name="max_volume" value="$(arg max_volume)"/>
 </node>
 
-<node pkg="walking_group_recovery" type="toggle_walking_group_recovery.py" name="toggle_walking_group_recovery" output="screen" respawn="true">
-    <arg name="sound_player_server" value="/walking_group_player/sound_player_service"/>
-    <arg name="music_file" value="$(arg music_file)"
+<node pkg="walking_group_recovery" type="toggle_walking_group_recovery_server.py" name="toggle_walking_group_recovery_server" output="screen" respawn="true">
+    <param name="sound_player_server" value="/walking_group_player/sound_player_service"/>
+    <param name="music_file" value="$(arg music_file)"/>
 </node>
 
 </launch>

--- a/walking_group_recovery/launch/walking_group_recovery.launch
+++ b/walking_group_recovery/launch/walking_group_recovery.launch
@@ -1,0 +1,26 @@
+<launch>
+
+<arg name="machine" default="localhost"/>
+<arg name="user" default=""/>
+
+<arg name="music_set" default="aaf_walking_group_recovery_sounds"/>
+<arg name="music_file" default="nooo.mp3"/>
+<arg name="audio_priority" default="0.9"/>
+<arg name="min_volume" default="0.2"/>
+<arg name="max_volume" default="1.0"/>
+
+<machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER)" user="$(arg user)" default="true"/>
+
+<node pkg="sound_player_server" type="sound_player.py" name="walking_group_player" output="screen" respawn="true">
+    <arg name="music_set" value="$(arg music_set)"/>
+    <arg name="audio_priority" value="$(arg audio_priority)"/>
+    <arg name="min_volume" value="$(arg min_volume)"/>
+    <arg name="max_volume" value="$(arg max_volume)"/>
+</node>
+
+<node pkg="walking_group_recovery" type="toggle_walking_group_recovery.py" name="toggle_walking_group_recovery" output="screen" respawn="true">
+    <arg name="sound_player_server" value="/walking_group_player/sound_player_service"/>
+    <arg name="music_file" value="$(arg music_file)"
+</node>
+
+</launch>

--- a/walking_group_recovery/package.xml
+++ b/walking_group_recovery/package.xml
@@ -26,6 +26,7 @@
   <build_depend>python-pygame</build_depend>
   <build_depend>pygame_managed_player</build_depend>
   <build_depend>mongodb_media_server</build_depend>
+  <build_depend>sound_player_server</build_depend>
 
   <run_depend>std_msgs</run_depend>
   <run_depend>actionlib</run_depend>
@@ -39,6 +40,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>pygame_managed_player</run_depend>
   <run_depend>mongodb_media_server</run_depend>
+  <run_depend>sound_player_server</run_depend>
 
   <export/>
 </package>

--- a/walking_group_recovery/scripts/toggle_walking_group_recovery_server.py
+++ b/walking_group_recovery/scripts/toggle_walking_group_recovery_server.py
@@ -9,10 +9,8 @@ class ToggleWalkingGroupRecoveryServer(object):
     def __init__(self):
         rospy.init_node('toggle_walking_group_recovery_server')
         #Not too nice but don't know a different way of using params in recovery behaviour
-        rospy.set_param("/walking_group_help/music_set", rospy.get_param("~music_set", "walking_group_recovery"))
-        rospy.set_param("/walking_group_help/audio_priority", rospy.get_param("~audio_priority", 0.9))
-        rospy.set_param("/walking_group_help/min_volume", rospy.get_param("~min_volume", 0.2))
-        rospy.set_param("/walking_group_help/max_volume", rospy.get_param("~max_volume",1.0))
+        rospy.set_param("/walking_group_help/sound_player_server", rospy.get_param("~sound_player_server", "walking_group_player"))
+        rospy.set_param("/walking_group_help/music_file", rospy.get_param("~music_file", "nooo.mp3"))
         self.service = rospy.Service('toggle_walking_group_recovery', ToggleWalkingGroupRecovery, self.change_recovery)
 
     def change_recovery(self, req):
@@ -33,4 +31,3 @@ class ToggleWalkingGroupRecoveryServer(object):
 if __name__ == '__main__':
     server = ToggleWalkingGroupRecoveryServer()
     rospy.spin()
-

--- a/walking_group_recovery/src/walking_group_recovery/walking_group_nav_states.py
+++ b/walking_group_recovery/src/walking_group_recovery/walking_group_nav_states.py
@@ -3,7 +3,6 @@ import rospy
 import smach
 from monitored_navigation.recover_state_machine import RecoverStateMachine
 from strands_monitored_nav_states.recover_nav_states import  SleepAndRetry
-from strands_monitored_nav_states.mongo_logger import MonitoredNavEventClass
 from walking_group_recovery_state import WalkingGroupRecovery
 
 class WalkingGroupNav(RecoverStateMachine):
@@ -19,12 +18,9 @@ class WalkingGroupNav(RecoverStateMachine):
             #                                    'do_other_recovery':'WALKING_HELP'})
             smach.StateMachine.add('WALKING_HELP',
                                    self.walking_help,
-                                   transitions={'recovered_with_help':'recovered_with_help', 
+                                   transitions={'recovered_with_help':'recovered_with_help',
                                                 'recovered_without_help':'recovered_without_help',
-                                                'not_recovered_with_help':'not_recovered_with_help', 
-                                                'not_recovered_without_help':'not_recovered_without_help', 
+                                                'not_recovered_with_help':'not_recovered_with_help',
+                                                'not_recovered_without_help':'not_recovered_without_help',
                                                 'preempted':'preempted',
                                                 'not_active':'not_recovered_without_help'})
-
-
-

--- a/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
+++ b/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
@@ -92,7 +92,7 @@ class WalkingGroupRecovery(RecoverState):
         #paths = roslib.packages.find_resource('walking_group_recovery', 'good_bad_ugly.mp3')
         #pygame.mixer.music.load(paths[0])
         #pygame.mixer.music.play()
-        PlaySoundServiceRequest req(self.music_file)
+        req = PlaySoundServiceRequest(self.music_file)
         resp = self.sound_player_server(req)
         print ("Played sound: " + str(resp.file_found) + " with priority " + str(resp.audio_priority))
         if self.being_helped:

--- a/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
+++ b/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
@@ -14,6 +14,7 @@ import pygame
 
 from pygame_managed_player.pygame_player import PyGamePlayer
 from mongodb_media_server import MediaClient
+from sound_player_server.srv import PlaySoundService, PlaySoundServiceRequest
 
 from random import randint
 
@@ -47,47 +48,10 @@ class WalkingGroupRecovery(RecoverState):
         self.help_finished_service_name="walking_help_finished"
         self.help_done_monitor=rospy.Service('/monitored_navigation/'+self.help_finished_service_name, Empty, self.help_finished_cb)
 
-        self.music_set      = rospy.get_param("/walking_group_help/music_set", "walking_group_recovery")
-        self.audio_priority = rospy.get_param("/walking_group_help/audio_priority", 0.9)
-        self.min_volume     = rospy.get_param("/walking_group_help/min_volume", 0.2)
-        self.max_volume     = rospy.get_param("/walking_group_help/max_volume", 1.0)
-        self.audio_folder   = join(expanduser('~'), '.ros', 'walking_group_recovery')
+        self.sound_player_name = rospy.get_param("/walking_group_help/sound_player_server", "sound_player_server")
+        self.music_file = rospy.get_param("/walking_group_help/music_file", "nooo.mp3")
 
-        print "Audio priority:"
-        print self.audio_priority
-
-        hostname = rospy.get_param('mongodb_host')
-        port = rospy.get_param('mongodb_port')
-
-        self.mc = MediaClient(hostname, port)
-        sets = self.mc.get_sets("Music")
-        object_id = None
-        for s in sets:
-            if s[0] == self.music_set:
-                object_id = s[2]
-
-        if object_id is None:
-            rospy.logwarn('Could not find any set in database matching walking_group_recovery')
-            return
-
-        file_set = self.mc.get_set(object_id)
-
-        if len(file_set) == 0:
-            rospy.logwarn('No audio files in walking group recovery media set')
-            return
-
-        if not exists(self.audio_folder):
-            makedirs(self.audio_folder)
-
-        for f in file_set:
-            file = self.mc.get_media(str(f[2]))
-            outfile = open(join(self.audio_folder, f[0]), 'wb')
-            filestr = file.read()
-            outfile.write(filestr)
-            outfile.close()
-
-        self.file_list = [join(self.audio_folder, f[0]) for f in file_set]
-
+        self.sound_player_server = rospy.ServiceProxy(self.sound_player_name, PlaySoundService)
 
     def help_offered_cb(self, req):
         self.being_helped=True
@@ -104,10 +68,6 @@ class WalkingGroupRecovery(RecoverState):
             self.ask_help_srv(self.service_msg)
         except rospy.ServiceException, e:
             rospy.logwarn("No means of asking for human help available.")
-
-    def get_random_song(self):
-        pos = randint(0, len(self.file_list)-1)
-        return self.file_list[pos]
 
     def active_execute(self, userdata):
         wait_for_nav_help_timeout=rospy.get_param('wait_for_nav_help_timeout',40)
@@ -132,9 +92,9 @@ class WalkingGroupRecovery(RecoverState):
         #paths = roslib.packages.find_resource('walking_group_recovery', 'good_bad_ugly.mp3')
         #pygame.mixer.music.load(paths[0])
         #pygame.mixer.music.play()
-        if self.file_list is not None and len(self.file_list) > 0:
-            self.player = PyGamePlayer(self.min_volume, self.max_volume, self.audio_priority, frequency=44100)
-            self.player.play_music(self.get_random_song(), blocking=False)
+        PlaySoundServiceRequest req(self.music_file)
+        resp = self.sound_player_server(req)
+        print ("Played sound: " + str(resp.file_found) + " with priority " + str(resp.audio_priority))
         if self.being_helped:
             self.service_msg.interaction_status=AskHelpRequest.BEING_HELPED
             self.service_msg.interaction_service=self.help_finished_service_name
@@ -162,7 +122,7 @@ class WalkingGroupRecovery(RecoverState):
 
 
     def finish_execution(self):
-        pygame.mixer.music.stop()
+        #pygame.mixer.music.stop()
         self.enable_motors(True)
         self.service_msg.interaction_status=AskHelpRequest.HELP_FINISHED
         self.service_msg.interaction_service='none'

--- a/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
+++ b/walking_group_recovery/src/walking_group_recovery/walking_group_recovery_state.py
@@ -53,6 +53,9 @@ class WalkingGroupRecovery(RecoverState):
         self.max_volume     = rospy.get_param("/walking_group_help/max_volume", 1.0)
         self.audio_folder   = join(expanduser('~'), '.ros', 'walking_group_recovery')
 
+        print "Audio priority:"
+        print self.audio_priority
+
         hostname = rospy.get_param('mongodb_host')
         port = rospy.get_param('mongodb_port')
 


### PR DESCRIPTION
Play sounds with the `sound_player_server` instead of internally. This allows `monitored_navigation` to be run on computers other than the main one. Added a launch file for launching all of the nodes needed.

This requires https://github.com/strands-project/strands_ui/pull/88 and a few changes to `aaf_deployment` that are coming up soon.
