### PR TITLE
Added a parameter for language in behaviours + strings for german

### DIFF
--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -21,6 +21,7 @@ class BacktrackServer(object):
     def __init__(self):
         rospy.init_node('backtrack_actionserver')
         self.consider_moving_success = True
+        self.deployment_language = rospy.get_param("/deployment_language", "english")
 
         # get ptu action client
         self.ptu_action_client = actionlib.SimpleActionClient('/SetPTUState', PtuGotoAction)
@@ -51,6 +52,8 @@ class BacktrackServer(object):
 
         rospy.loginfo("Backtrack behaviour got marytts action")
         self.speech = "I am stuck here, so I might try moving backwards. Please get out of the way."
+        if self.deployment_language == "german":
+            self.speech = "Ich habe mich ein wenig verfahren und werde eventuell versuchen rückwärts zu fahren. Ich würde dich daher bitten etwas Platz zu machen."
 
         # set correct parameters and announce server
         self.global_plan = None

--- a/backtrack_behaviour/scripts/backtrack_server.py
+++ b/backtrack_behaviour/scripts/backtrack_server.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import rospy
 
@@ -53,7 +54,7 @@ class BacktrackServer(object):
         rospy.loginfo("Backtrack behaviour got marytts action")
         self.speech = "I am stuck here, so I might try moving backwards. Please get out of the way."
         if self.deployment_language == "german":
-            self.speech = "Ich habe mich ein wenig verfahren und werde eventuell versuchen rückwärts zu fahren. Ich würde dich daher bitten etwas Platz zu machen."
+            self.speech = "Ich habe mich ein wenig verfahren und werde eventuell versuchen rückwärts zu fahren. Ich würde dich daher bitten, etwas Platz zu machen."
 
         # set correct parameters and announce server
         self.global_plan = None

--- a/strands_human_help/src/strands_human_help/help_screen.py
+++ b/strands_human_help/src/strands_human_help/help_screen.py
@@ -8,11 +8,13 @@ from monitored_navigation.ui_helper import UIHelper
 import strands_webserver.client_utils
 import strands_webserver.page_utils
 
- 
+
 class HelpScreen(UIHelper):
 
     def __init__(self, webserver_srv_prefix='strands_webserver', service_prefix='/monitored_navigation', set_http_root=False):
-        
+
+        self.deployment_language = rospy.get_param("/deployment_language", "english")
+
         got_service=False
         while not got_service:
             try:
@@ -24,31 +26,43 @@ class HelpScreen(UIHelper):
             if rospy.is_shutdown():
                 return
 
-        rospy.loginfo("help via screen got webserver services")   
+        rospy.loginfo("help via screen got webserver services")
         self.display_no = rospy.get_param("~display", 0)
         if set_http_root:
-            strands_webserver.client_utils.set_http_root(roslib.packages.get_pkg_dir('strands_human_help/html'))           
+            strands_webserver.client_utils.set_http_root(roslib.packages.get_pkg_dir('strands_human_help/html'))
         self.display_main_page()
-        
-        
-        self.help_label='HELP'
-        self.finish_label='OK'
-        self.bumper_help_html='Help! My bumper is stuck against something. If you can help me, please press the button below.'
-        self.nav_help_html='Help! I appear to have trouble moving past an obstruction. If you can help me, please press the button below.' 
-        self.magnetic_stip_help_html='I feel very unconfortable about moving in this area, please call one of my handlers.'
-        self.help_instructions_html='Thank you! Please follow these instructions:' 
-        self.help_instructions_html += '<hr/>' 
-        self.help_instructions_html += '<ol>'
-        self.help_instructions_html += '<li>Push me away from any obstructions into a clear space</li>'
-        self.help_instructions_html += '<li>Press the '+ self.finish_label +' button below</li>'
-        self.help_instructions_html += '</ol>'
-    
+
+        if self.deployment_language == "german":
+            self.help_label='RETTE MICH'
+            self.finish_label='OK'
+            self.bumper_help_html='Hilfe! Ich bin in ein Hindernis gefahren. Wenn du mir weiterhelfen kannst, bitte drücke diesen Knopf.'
+            self.nav_help_html='Hilfe! Ich habe Problem ein Hindernis zu passieren. Wenn du mir helfen kannst, bitte drücke diesen Knopf.'
+            self.magnetic_stip_help_html='Ich bin versehentlich in eine unerlaubte Zone gefahren. Bitte benachrichtige meine Betreuer.'
+            self.help_instructions_html='Dankeschön! Bitte folge diesen Anweisungen:'
+            self.help_instructions_html += '<hr/>'
+            self.help_instructions_html += '<ol>'
+            self.help_instructions_html += '<li>Schiebe mich in eine freie Umgebung.</li>'
+            self.help_instructions_html += '<li>Drücke den ' + self.finish_label + ' Knopf.</li>'
+            self.help_instructions_html += '</ol>'
+        else:
+            self.help_label='HELP'
+            self.finish_label='OK'
+            self.bumper_help_html='Help! My bumper is stuck against something. If you can help me, please press the button below.'
+            self.nav_help_html='Help! I appear to have trouble moving past an obstruction. If you can help me, please press the button below.'
+            self.magnetic_stip_help_html='I feel very unconfortable about moving in this area, please call one of my handlers.'
+            self.help_instructions_html='Thank you! Please follow these instructions:'
+            self.help_instructions_html += '<hr/>'
+            self.help_instructions_html += '<ol>'
+            self.help_instructions_html += '<li>Push me away from any obstructions into a clear space</li>'
+            self.help_instructions_html += '<li>Press the '+ self.finish_label +' button below</li>'
+            self.help_instructions_html += '</ol>'
+
         self.service_prefix=service_prefix
         UIHelper.__init__(self)
-        
-        rospy.loginfo("help via screen initialized")  
 
-  
+        rospy.loginfo("help via screen initialized")
+
+
     def ask_help(self, failed_component, interaction_service, n_fails):
         if failed_component=='navigation':
             self.generate_help_content(self.help_label, self.nav_help_html,  interaction_service)
@@ -56,26 +70,24 @@ class HelpScreen(UIHelper):
             self.generate_help_content(self.help_label, self.bumper_help_html,  interaction_service)
         elif failed_component=='magnetic_strip':
             self.generate_help_content(None, self.magnetic_stip_help_html,  interaction_service)
-        
+
     def being_helped(self, failed_component, interaction_service, n_fails):
         self.generate_help_content(self.finish_label, self.help_instructions_html,  interaction_service)
-        
+
     def help_finished(self, failed_component, interaction_service, n_fails):
         self.display_main_page()
-        
+
     def help_failed(self, failed_component, interaction_service, n_fails):
         self.ask_help(failed_component, interaction_service, n_fails)
-    
-    
+
+
     def display_main_page(self,):
         strands_webserver.client_utils.display_relative_page(self.display_no, 'index.html')
-    
+
     def generate_help_content(self,label, html, interaction_service):
         if label is None:
             content=self.magnetic_stip_help_html
         else:
             buttons = [(label, interaction_service)]
-            content = strands_webserver.page_utils.generate_alert_button_page(html, buttons, self.service_prefix)        
+            content = strands_webserver.page_utils.generate_alert_button_page(html, buttons, self.service_prefix)
         strands_webserver.client_utils.display_content(self.display_no, content)
-        
-

--- a/strands_human_help/src/strands_human_help/help_screen.py
+++ b/strands_human_help/src/strands_human_help/help_screen.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import rospy
 import roslib

--- a/strands_human_help/src/strands_human_help/help_speech.py
+++ b/strands_human_help/src/strands_human_help/help_speech.py
@@ -7,10 +7,12 @@ from monitored_navigation.ui_helper import UIHelper
 import actionlib
 from mary_tts.msg import maryttsAction, maryttsGoal
 
-    
+
 class HelpSpeech(UIHelper):
 
     def __init__(self):
+
+        self.deployment_language = rospy.get_param("/deployment_language", "english")
 
         self.speaker=actionlib.SimpleActionClient('/speak', maryttsAction)
         got_server=self.speaker.wait_for_server(rospy.Duration(1))
@@ -19,21 +21,28 @@ class HelpSpeech(UIHelper):
             got_server=self.speaker.wait_for_server(rospy.Duration(1))
             if rospy.is_shutdown():
                 return
-        
-        rospy.loginfo("Help via speech got marytts action") 
-        
-        self.nav_help_speech='I am having problems moving. Please check my screen for instructions on how to help me.'
-        self.bumper_help_speech='My bumper is being pressed. Please check my screen for instructions on how to help me.'
-        self.magnetic_help_speech="I am too close to these stairs, and afraid to move. Please call one of my handlers."
-        self.help_failed_speech='Something is still wrong. Are you sure I am in a clear area?'
-        self.help_finished_speech='Thank you! I will be on my way.'
-        
+
+        rospy.loginfo("Help via speech got marytts action")
+
+        if self.deployment_language == "german":
+            self.nav_help_speech='Ich habe Probleme weiterzufahren. Bitte folge diesen Anweisungen um mir zu helfen.'
+            self.bumper_help_speech='Ich bin in ein Hindernis gefahren. Bitte folge diesen Anweisungen um mir zu helfen.'
+            self.magnetic_help_speech="Ich befinde mich zu nahe an den Stiegen und habe Angst weiterzufahren. Bitte benachrichtige meine Betreuer."
+            self.help_failed_speech='Ich habe leider noch immer Problem weiterzufahren. Befinde ich mich wirklich in einer freien Umgebung ohne Hindernisse?'
+            self.help_finished_speech='Danke! Ich mache mich wieder auf den Weg.'
+        else:
+            self.nav_help_speech='I am having problems moving. Please check my screen for instructions on how to help me.'
+            self.bumper_help_speech='My bumper is being pressed. Please check my screen for instructions on how to help me.'
+            self.magnetic_help_speech="I am too close to these stairs, and afraid to move. Please call one of my handlers."
+            self.help_failed_speech='Something is still wrong. Are you sure I am in a clear area?'
+            self.help_finished_speech='Thank you! I will be on my way.'
+
         self.was_helped=False
-        
+
         UIHelper.__init__(self)
-        
+
         rospy.loginfo("Help via speech initialized")
- 
+
 
     def ask_help(self, failed_component, interaction_service, n_fails):
         if failed_component=='navigation':
@@ -42,23 +51,21 @@ class HelpSpeech(UIHelper):
             self.call_speech(self.bumper_help_speech)
         elif failed_component=='magnetic_strip':
             self.call_speech(self.magnetic_help_speech)
-        
+
     def being_helped(self, failed_component, interaction_service, n_fails):
         self.was_helped=True
         return
-        
+
     def help_finished(self, failed_component, interaction_service, n_fails):
         if self.was_helped:
             self.call_speech(self.help_finished_speech)
         self.was_helped=False
-        
+
     def help_failed(self, failed_component, interaction_service, n_fails):
         if self.was_helped:
             self.call_speech(self.help_failed_speech)
-    
-   
+
+
     def call_speech(self, text):
         self.speaker.send_goal(maryttsGoal(text=text))
         #self.speaker.wait_for_result()
- 
-  

--- a/strands_human_help/src/strands_human_help/help_speech.py
+++ b/strands_human_help/src/strands_human_help/help_speech.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import rospy
 
@@ -28,7 +29,7 @@ class HelpSpeech(UIHelper):
             self.nav_help_speech='Ich habe Probleme weiterzufahren. Bitte folge diesen Anweisungen um mir zu helfen.'
             self.bumper_help_speech='Ich bin in ein Hindernis gefahren. Bitte folge diesen Anweisungen um mir zu helfen.'
             self.magnetic_help_speech="Ich befinde mich zu nahe an den Stiegen und habe Angst weiterzufahren. Bitte benachrichtige meine Betreuer."
-            self.help_failed_speech='Ich habe leider noch immer Problem weiterzufahren. Befinde ich mich wirklich in einer freien Umgebung ohne Hindernisse?'
+            self.help_failed_speech='Ich habe leider noch immer Problem, weiterzufahren. Befinde ich mich wirklich in einer freien Umgebung ohne Hindernisse?'
             self.help_finished_speech='Danke! Ich mache mich wieder auf den Weg.'
         else:
             self.nav_help_speech='I am having problems moving. Please check my screen for instructions on how to help me.'


### PR DESCRIPTION
The ros parameter `/deployment_language` now determines which language to use for the help_screen, help_speech and backtrack_behaviour. Currently putting the language string directly in the python code but should be OK as we only have 2 languages. Tested with both german and english.
