### PR TITLE
better recover stuck on carpet

### DIFF
--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/monitor_stuck_on_carpet.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/monitor_stuck_on_carpet.py
@@ -23,7 +23,7 @@ class MonitorStuckOnCarpet(MonitorState):
         self.pub_msg=Bool(False)
         
         
-        MonitorState.__init__(self, "/monitored_navigation/stuck_on_carpet", Bool,self.monitor_cb)
+        MonitorState.__init__(self, "/monitored_navigation/stuck_on_carpet", Bool,self.monitor_cb, input_keys=['n_fails'], output_keys=['n_fails'])
         
 
 
@@ -45,6 +45,8 @@ class MonitorStuckOnCarpet(MonitorState):
 
     """ Test the message and decide exit or not """
     def monitor_cb(self,  ud,  msg):
+        if msg.data:
+            ud.n_fails+=1
         return not msg.data
 
 

--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_carpet_state.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_carpet_state.py
@@ -13,6 +13,8 @@ class CarpetState(RecoverState):
                         name=name,
                         outcomes=['recovered_with_help', 'recovered_without_help','not_recovered_with_help', 'not_recovered_without_help', 'preempted'],
                         is_active=is_active,
+                        input_keys=['n_fails'],
+                        output_keys=['n_fails'],
                         max_recovery_attempts=max_recovery_attempts
                         )
         self.was_helped=False
@@ -26,7 +28,12 @@ class CarpetState(RecoverState):
         if self.preempt_requested(): 
             self.service_preempt()
             return 'preempted'
-            
+        
+        current_time=rospy.Time.now()
+        if current_time-self.last_call < rospy.Duration(60):
+            userdata.n_fails+=1
+        self.last_call=current_time
+        
         #small forward vel to unstuck robot
         self.vel_cmd.linear.x=0.8
         self.vel_cmd.angular.z=0.4

--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_carpet_state.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_carpet_state.py
@@ -1,0 +1,51 @@
+import rospy
+import smach
+from monitored_navigation.recover_state import RecoverState
+from geometry_msgs.msg import Twist
+
+   
+class CarpetState(RecoverState):
+    def __init__(self,
+                 name="recover_stuck_on_carpet",
+                 is_active=True,
+                 max_recovery_attempts=float("inf")):
+        RecoverState.__init__(self,
+                        name=name,
+                        outcomes=['recovered_with_help', 'recovered_without_help','not_recovered_with_help', 'not_recovered_without_help', 'preempted'],
+                        is_active=is_active,
+                        max_recovery_attempts=max_recovery_attempts
+                        )
+        self.was_helped=False
+        self.vel_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
+        self.vel_cmd = Twist()
+        
+        self.last_call=rospy.Time.now()
+        
+
+    def active_execute(self,userdata):
+        if self.preempt_requested(): 
+            self.service_preempt()
+            return 'preempted'
+            
+        #small forward vel to unstuck robot
+        self.vel_cmd.linear.x=0.8
+        self.vel_cmd.angular.z=0.4
+        for i in range(0,4): 
+            self.vel_pub.publish(self.vel_cmd)
+            self.vel_cmd.linear.x=self.vel_cmd.linear.x-0.2
+            self.vel_cmd.angular.z=self.vel_cmd.angular.z-0.2  
+            rospy.sleep(0.2)
+            
+        self.vel_cmd.linear.x=0.0
+        self.vel_cmd.angular.z=0.0
+        self.vel_pub.publish(self.vel_cmd)
+                
+        if self.preempt_requested(): 
+            self.service_preempt()
+            return 'preempted'
+
+        #TODO: find way to check if behaviour was successful       
+        if True:     
+            return 'recovered_without_help'
+        else:
+            return 'not_recovered_with_help'

--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_nav_states.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_nav_states.py
@@ -126,10 +126,10 @@ class Help(RecoverState):
         self.service_msg=AskHelpRequest()
         self.service_msg.failed_component='navigation'
 
-        self.help_offered_service_name='nav_help_offered'
+        self.help_offered_service_name=self.name+'_offered'
         self.help_offered_monitor=rospy.Service('/monitored_navigation/'+self.help_offered_service_name, Empty, self.help_offered_cb)
 
-        self.help_finished_service_name="nav_help_finished"
+        self.help_finished_service_name=self.name+"_finished"
         self.help_done_monitor=rospy.Service('/monitored_navigation/'+self.help_finished_service_name, Empty, self.help_finished_cb)
 
     def help_offered_cb(self, req):

--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_stuck_on_carpet_backtrack_help.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_stuck_on_carpet_backtrack_help.py
@@ -1,0 +1,33 @@
+import rospy
+import smach
+from monitored_navigation.recover_state_machine import RecoverStateMachine
+from recover_carpet_state import CarpetState
+from recover_nav_states import Backtrack, Help
+from geometry_msgs.msg import Twist
+
+class RecoverStuckOnCarpetBacktrackHelp(RecoverStateMachine):
+    def __init__(self,):
+        RecoverStateMachine.__init__(self,input_keys=['n_fails'],output_keys=['n_fails'])
+        self.state=CarpetState(max_recovery_attempts=10)
+        self.backtrack=Backtrack(name='carpet_backtrack', max_recovery_attempts=12)   
+        self.carpet_help=Help("carpet_help")
+        with self:
+            smach.StateMachine.add('CARPET_STATE',
+                                   self.state,
+                                   transitions={'preempted':'preempted',
+                                                'recovered_without_help':'recovered_without_help',
+                                                'not_active':'BACKTRACK'})
+            smach.StateMachine.add('BACKTRACK',
+                                   self.backtrack,
+                                   transitions={'succeeded':'recovered_without_help',
+                                                'failure':'CARPET_HELP',
+                                                'not_active':'CARPET_HELP',
+                                                'preempted':'preempted'})
+            smach.StateMachine.add('CARPET_HELP',
+                                   self.carpet_help,
+                                   transitions={'recovered_with_help':'recovered_with_help', 
+                                                'recovered_without_help':'recovered_without_help',
+                                                'not_recovered_with_help':'not_recovered_with_help', 
+                                                'not_recovered_without_help':'not_recovered_without_help',
+                                                'not_active':'not_recovered_without_help',
+                                                'preempted':'preempted'})

--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_stuck_on_carpet_no_help.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_stuck_on_carpet_no_help.py
@@ -1,7 +1,7 @@
 import rospy
 import smach
 from monitored_navigation.recover_state_machine import RecoverStateMachine
-from monitored_navigation.recover_state import RecoverState
+from recover_carpet_state import CarpetState
 from geometry_msgs.msg import Twist
 
 class RecoverStuckOnCarpetNoHelp(RecoverStateMachine):
@@ -17,46 +17,4 @@ class RecoverStuckOnCarpetNoHelp(RecoverStateMachine):
                                                 'preempted':'preempted',
                                                 'not_active':'not_recovered_without_help'})
    
-class CarpetState(RecoverState):
-    def __init__(self,
-                 name="recover_stuck_on_carpet",
-                 is_active=True,
-                 max_recovery_attempts=float("inf")):
-        RecoverState.__init__(self,
-                        name=name,
-                        outcomes=['recovered_with_help', 'recovered_without_help','not_recovered_with_help', 'not_recovered_without_help', 'preempted'],
-                        is_active=is_active,
-                        max_recovery_attempts=max_recovery_attempts
-                        )
-        self.was_helped=False
-        self.vel_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
-        self.vel_cmd = Twist()
-        
 
-    def active_execute(self,userdata):
-        if self.preempt_requested(): 
-            self.service_preempt()
-            return 'preempted'
-            
-        #small forward vel to unstuck robot
-        self.vel_cmd.linear.x=0.8
-        self.vel_cmd.angular.z=0.4
-        for i in range(0,4): 
-            self.vel_pub.publish(self.vel_cmd)
-            self.vel_cmd.linear.x=self.vel_cmd.linear.x-0.2
-            self.vel_cmd.angular.z=self.vel_cmd.angular.z-0.2  
-            rospy.sleep(0.2)
-            
-        self.vel_cmd.linear.x=0.0
-        self.vel_cmd.angular.z=0.0
-        self.vel_pub.publish(self.vel_cmd)
-                
-        if self.preempt_requested(): 
-            self.service_preempt()
-            return 'preempted'
-
-        #TODO: find way to check if behaviour was successful       
-        if True:     
-            return 'recovered_without_help'
-        else:
-            return 'not_recovered_with_help'

--- a/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_stuck_on_carpet_no_help.py
+++ b/strands_monitored_nav_states/src/strands_monitored_nav_states/recover_stuck_on_carpet_no_help.py
@@ -6,7 +6,7 @@ from geometry_msgs.msg import Twist
 
 class RecoverStuckOnCarpetNoHelp(RecoverStateMachine):
     def __init__(self,max_recovery_attempts=float("inf")):
-        RecoverStateMachine.__init__(self)
+        RecoverStateMachine.__init__(self,input_keys=['n_fails'],output_keys=['n_fails'])
         self.state=CarpetState(max_recovery_attempts=max_recovery_attempts)
         
         with self:

--- a/strands_recovery_behaviours/config/monitored_nav_config.yaml
+++ b/strands_recovery_behaviours/config/monitored_nav_config.yaml
@@ -14,8 +14,8 @@ monitor_recovery_pairs:
         package: strands_monitored_nav_states
         monitor_file: monitor_stuck_on_carpet
         monitor_class: MonitorStuckOnCarpet
-        recovery_file: recover_stuck_on_carpet_no_help
-        recovery_class: RecoverStuckOnCarpetNoHelp
+        recovery_file: recover_stuck_on_carpet_backtrack_help
+        recovery_class: RecoverStuckOnCarpetBacktrackHelp
     -   name: magnetic_strip
         package: strands_monitored_nav_states
         monitor_file: monitor_magnetic_strip


### PR DESCRIPTION
this extends the recover stuck on carpet state to try backtracking and asking for help when the robot gets stuck for a long time. ran on bob on last deployment, I forgot to create the PR upstream then.